### PR TITLE
To work with webhook payloads

### DIFF
--- a/lib/src/models/detect_intent_response/query_result.dart
+++ b/lib/src/models/detect_intent_response/query_result.dart
@@ -77,7 +77,9 @@ class QueryResult extends Equatable {
 
   /// The collection of rich messages to present to the user.
   final List<Message>? fulfillmentMessages;
-
+  ///To detect the input from webhook and have payload from webhook
+  final String? webhookSource;
+  final Map<String, dynamic>? webhookPayload;
   /// The collection of output contexts.
   ///
   /// If applicable, [outputContexts.parameters] contains entries with name
@@ -129,6 +131,8 @@ class QueryResult extends Equatable {
     this.parameters,
     this.allRequiredParamsPresent,
     this.fulfillmentMessages,
+    this.webhookSource,
+    this.webhookPayload,
     this.outputContexts,
     this.intent,
     this.intentDetectionConfidence,
@@ -152,6 +156,8 @@ class QueryResult extends Equatable {
         parameters,
         allRequiredParamsPresent,
         fulfillmentMessages,
+        webhookSource,
+        webhookPayload,
         outputContexts,
         intent,
         intentDetectionConfidence,

--- a/lib/src/models/detect_intent_response/query_result.g.dart
+++ b/lib/src/models/detect_intent_response/query_result.g.dart
@@ -18,6 +18,8 @@ QueryResult _$QueryResultFromJson(Map<String, dynamic> json) {
     fulfillmentMessages: (json['fulfillmentMessages'] as List<dynamic>?)
         ?.map((e) => Message.fromJson(e as Map<String, dynamic>))
         .toList(),
+    webhookSource: json['webhookSource'] as String?,
+    webhookPayload: json['webhookPayload'] as Map<String, dynamic>?,
     outputContexts: (json['outputContexts'] as List<dynamic>?)
         ?.map((e) => Context.fromJson(e as Map<String, dynamic>))
         .toList(),
@@ -52,6 +54,8 @@ Map<String, dynamic> _$QueryResultToJson(QueryResult instance) {
   writeNotNull('allRequiredParamsPresent', instance.allRequiredParamsPresent);
   writeNotNull('fulfillmentMessages',
       instance.fulfillmentMessages?.map((e) => e.toJson()).toList());
+  writeNotNull('webhookPayload', instance.webhookPayload);
+  writeNotNull('webhookSource', instance.webhookSource);
   writeNotNull('outputContexts',
       instance.outputContexts?.map((e) => e.toJson()).toList());
   writeNotNull('intent', instance.intent?.toJson());

--- a/lib/src/models/query_input/query_input.dart
+++ b/lib/src/models/query_input/query_input.dart
@@ -26,12 +26,12 @@ class QueryInput extends Equatable {
   final TextInput? text;
 
   /// The event to be processed.
-  final EventInput? eventInput;
+  final EventInput? event;
 
   /// {@macro query_input_template}
   QueryInput({
     this.text,
-    this.eventInput,
+    this.event,
   });
 
   ///
@@ -44,6 +44,6 @@ class QueryInput extends Equatable {
   @override
   List<Object?> get props => [
         text,
-        eventInput,
+        event,
       ];
 }

--- a/lib/src/models/query_input/query_input.g.dart
+++ b/lib/src/models/query_input/query_input.g.dart
@@ -11,9 +11,9 @@ QueryInput _$QueryInputFromJson(Map<String, dynamic> json) {
     text: json['text'] == null
         ? null
         : TextInput.fromJson(json['text'] as Map<String, dynamic>),
-    eventInput: json['eventInput'] == null
+    event: json['event'] == null
         ? null
-        : EventInput.fromJson(json['eventInput'] as Map<String, dynamic>),
+        : EventInput.fromJson(json['event'] as Map<String, dynamic>),
   );
 }
 
@@ -27,6 +27,6 @@ Map<String, dynamic> _$QueryInputToJson(QueryInput instance) {
   }
 
   writeNotNull('text', instance.text?.toJson());
-  writeNotNull('eventInput', instance.eventInput?.toJson());
+  writeNotNull('event', instance.event?.toJson());
   return val;
 }


### PR DESCRIPTION
1.The query result parameter of the dialogflow contains two other fields namely webhook source and webhook payload. 
I have added these two fields in query_result.dart and query_result.g.dart 

```
"webhookStatuses": [
    {
      object (Status)
    }
  ],
  "webhookPayloads": [
    {
      object
    }
  ],
```

The structure of the query result can be seen in https://cloud.google.com/dialogflow/cx/docs/reference/rest/v3/QueryResult


2. Event input works with the event rather than event input. 

```
{
  "query_input": {
    "event": {
      "name": "username",
      "parameters":{"username":name},
      "languageCode": "en-US"
    }
  }
}
```
Changing eventinput in query_input and query_input.g into event made it work. 