### PR TITLE
Renamed eventInput to event

### DIFF
--- a/lib/src/models/query_input/query_input.dart
+++ b/lib/src/models/query_input/query_input.dart
@@ -26,12 +26,12 @@ class QueryInput extends Equatable {
   final TextInput? text;
 
   /// The event to be processed.
-  final EventInput? eventInput;
+  final EventInput? event;
 
   /// {@macro query_input_template}
   QueryInput({
     this.text,
-    this.eventInput,
+    this.event,
   });
 
   ///
@@ -44,6 +44,6 @@ class QueryInput extends Equatable {
   @override
   List<Object?> get props => [
         text,
-        eventInput,
+        event,
       ];
 }

--- a/lib/src/models/query_input/query_input.g.dart
+++ b/lib/src/models/query_input/query_input.g.dart
@@ -11,9 +11,9 @@ QueryInput _$QueryInputFromJson(Map<String, dynamic> json) {
     text: json['text'] == null
         ? null
         : TextInput.fromJson(json['text'] as Map<String, dynamic>),
-    eventInput: json['eventInput'] == null
+    event: json['event'] == null
         ? null
-        : EventInput.fromJson(json['eventInput'] as Map<String, dynamic>),
+        : EventInput.fromJson(json['event'] as Map<String, dynamic>),
   );
 }
 
@@ -27,6 +27,6 @@ Map<String, dynamic> _$QueryInputToJson(QueryInput instance) {
   }
 
   writeNotNull('text', instance.text?.toJson());
-  writeNotNull('eventInput', instance.eventInput?.toJson());
+  writeNotNull('event', instance.event?.toJson());
   return val;
 }


### PR DESCRIPTION
According to the Google documentation [here](https://cloud.google.com/dialogflow/es/docs/reference/rest/v2beta1/QueryInput), the name of the EventInput parameter in the QueryInput class is not "eventInput", but "event".

The PR correct the name of the parameter, so EventInput works with the library. 