### PR TITLE
Update sentiment.g.dart

### DIFF
--- a/lib/src/models/detect_intent_response/sentiment.dart
+++ b/lib/src/models/detect_intent_response/sentiment.dart
@@ -12,11 +12,13 @@ part 'sentiment.g.dart';
 class Sentiment extends Equatable {
   /// Sentiment score between -1.0 (negative sentiment) and 1.0
   /// (positive sentiment).
+  @JsonKey(defaultValue: 0)
   final double score;
 
   /// A non-negative number in the [0, +inf) range, which represents the
   /// absolute magnitude of sentiment, regardless of score
   /// (positive or negative).
+  @JsonKey(defaultValue: 0)
   final double magnitude;
 
   /// {@macro sentiment_template}

--- a/lib/src/models/detect_intent_response/sentiment.g.dart
+++ b/lib/src/models/detect_intent_response/sentiment.g.dart
@@ -7,8 +7,8 @@ part of 'sentiment.dart';
 // **************************************************************************
 
 Sentiment _$SentimentFromJson(Map<String, dynamic> json) => Sentiment(
-      score: (json['score'] as num).toDouble(),
-      magnitude: (json['magnitude'] as num).toDouble(),
+      score: (json['score'] == null) ? 0 : (json['score'] as num).toDouble(),
+      magnitude: (json['magnitude'] == null)? 0: (json['magnitude'] as num).toDouble(),
     );
 
 Map<String, dynamic> _$SentimentToJson(Sentiment instance) => <String, dynamic>{


### PR DESCRIPTION
Cast error fixed: if score is "null" it cannot be cast as a "num" type

